### PR TITLE
Confirm session bookings

### DIFF
--- a/client/src/pages/BookAppointment.js
+++ b/client/src/pages/BookAppointment.js
@@ -18,6 +18,58 @@ const BookAppointment = () => {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState('');
 
+  // Fallback services if API fails
+  const fallbackServices = [
+    {
+      id: 1,
+      title: 'Individual Therapy',
+      description: 'One-on-one therapy sessions tailored to your specific needs and goals.',
+      icon: '👤',
+      duration: '50-60 minutes',
+      price: '$150 per session'
+    },
+    {
+      id: 2,
+      title: 'Couples Therapy',
+      description: 'Specialized therapy for couples to improve communication and strengthen relationships.',
+      icon: '💑',
+      duration: '80-90 minutes',
+      price: '$200 per session'
+    },
+    {
+      id: 3,
+      title: 'Family Therapy',
+      description: 'Family-focused therapy to address conflicts and improve family dynamics.',
+      icon: '👨‍👩‍👧‍👦',
+      duration: '80-90 minutes',
+      price: '$200 per session'
+    },
+    {
+      id: 4,
+      title: 'Child Therapy',
+      description: 'Specialized therapy for children and adolescents using age-appropriate techniques.',
+      icon: '🧒',
+      duration: '45-50 minutes',
+      price: '$120 per session'
+    },
+    {
+      id: 5,
+      title: 'Group Therapy',
+      description: 'Therapeutic groups for shared experiences and peer support.',
+      icon: '👥',
+      duration: '90 minutes',
+      price: '$80 per session'
+    },
+    {
+      id: 6,
+      title: 'Assessment',
+      description: 'Comprehensive psychological assessments and evaluations.',
+      icon: '📋',
+      duration: '2-3 hours',
+      price: '$300 per assessment'
+    }
+  ];
+
   useEffect(() => {
     const fetchServices = async () => {
       try {
@@ -25,6 +77,8 @@ const BookAppointment = () => {
         setServices(response.data);
       } catch (error) {
         console.error('Error fetching services:', error);
+        // Use fallback services if API fails
+        setServices(fallbackServices);
       }
     };
 


### PR DESCRIPTION
Add fallback services to the appointment booking page to ensure service type options are always available, even if the API fails to fetch them.